### PR TITLE
ENH: Add USB drive export for CSV files with directory picker

### DIFF
--- a/manifest.scm
+++ b/manifest.scm
@@ -20,6 +20,7 @@
       "python-django"
       "python-asgiref"
       "python-sqlparse"
+      "python-whitenoise"
 
       ;; Testing
       "python-pytest"

--- a/monksystem/base/templates/base/file.html
+++ b/monksystem/base/templates/base/file.html
@@ -87,8 +87,9 @@
 
         <!-- Export CSV tab -->
         <div class="tab-pane fade" id="csv" role="tabpanel" aria-labelledby="csv-tab">
-            <form action="{% url 'download_format_csv' file.id %}" method="post">
+            <form id="csv-export-form" action="{% url 'download_format_csv' file.id %}" method="post">
                 {% csrf_token %}
+                <input type="hidden" name="export_dir" id="csv-export-dir">
                 <h6 class="mb-2">Channel Selection</h6>
                 <div class="d-flex flex-wrap gap-3 mb-3">
                     {% for channel in content.channels %}
@@ -119,10 +120,36 @@
                                placeholder="End time…" class="form-control">
                     </div>
                 </div>
-                <button type="submit" class="btn btn-success">
-                    <i class="bi bi-download me-1"></i>Download CSV
+                <button type="button" id="csv-export-btn" class="btn btn-success">
+                    <i class="bi bi-download me-1"></i>Export CSV
                 </button>
             </form>
+
+            <!-- Export result alert -->
+            <div id="csv-export-result" class="mt-3" style="display:none;"></div>
+        </div>
+
+        <!-- Drive picker modal -->
+        <div class="modal fade" id="drivepickerModal" tabindex="-1" aria-labelledby="drivepickerLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="drivepickerLabel">
+                            <i class="bi bi-usb-drive me-2"></i>Select Export Drive
+                        </h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body" id="drivepicker-body">
+                        <p class="text-muted">Loading available drives…</p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="button" class="btn btn-success" id="drivepicker-confirm" disabled>
+                            <i class="bi bi-check-lg me-1"></i>Save to Drive
+                        </button>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <!-- Download Raw tab -->
@@ -182,6 +209,72 @@
             checkboxes.forEach(cb => cb.checked = true));
         document.querySelector('.deselect-all-btn')?.addEventListener('click', () =>
             checkboxes.forEach(cb => cb.checked = false));
+
+        // CSV export: open drive picker modal instead of submitting directly
+        const exportBtn = document.getElementById('csv-export-btn');
+        const modal = new bootstrap.Modal(document.getElementById('drivepickerModal'));
+        const modalBody = document.getElementById('drivepicker-body');
+        const confirmBtn = document.getElementById('drivepicker-confirm');
+        const exportDirInput = document.getElementById('csv-export-dir');
+        const resultDiv = document.getElementById('csv-export-result');
+
+        exportBtn.addEventListener('click', function () {
+            confirmBtn.disabled = true;
+            modalBody.innerHTML = '<p class="text-muted">Loading available drives…</p>';
+            modal.show();
+
+            fetch('{% url "list_export_dirs" %}')
+                .then(r => r.json())
+                .then(data => {
+                    if (!data.dirs || data.dirs.length === 0) {
+                        modalBody.innerHTML = '<p class="text-warning"><i class="bi bi-exclamation-triangle me-1"></i>No drives found in /run/media/rafael. Please insert a USB drive.</p>';
+                        return;
+                    }
+                    let html = '<div class="list-group">';
+                    data.dirs.forEach((d, i) => {
+                        html += `<label class="list-group-item list-group-item-action">
+                            <input class="form-check-input me-2" type="radio" name="drive-pick" value="${d.path}" id="drive_${i}">
+                            <i class="bi bi-usb-drive me-2"></i><strong>${d.name}</strong>
+                            <small class="text-muted ms-2">${d.path}</small>
+                        </label>`;
+                    });
+                    html += '</div>';
+                    modalBody.innerHTML = html;
+
+                    modalBody.querySelectorAll('input[name="drive-pick"]').forEach(radio => {
+                        radio.addEventListener('change', () => confirmBtn.disabled = false);
+                    });
+                })
+                .catch(() => {
+                    modalBody.innerHTML = '<p class="text-danger">Failed to list drives.</p>';
+                });
+        });
+
+        confirmBtn.addEventListener('click', function () {
+            const selected = modalBody.querySelector('input[name="drive-pick"]:checked');
+            if (!selected) return;
+            exportDirInput.value = selected.value;
+            modal.hide();
+
+            confirmBtn.disabled = true;
+            const form = document.getElementById('csv-export-form');
+            const formData = new FormData(form);
+
+            fetch(form.action, { method: 'POST', body: formData })
+                .then(r => r.json())
+                .then(data => {
+                    resultDiv.style.display = '';
+                    if (data.status === 'ok') {
+                        resultDiv.innerHTML = `<div class="alert alert-success"><i class="bi bi-check-circle me-2"></i>Saved to <code>${data.path}</code></div>`;
+                    } else {
+                        resultDiv.innerHTML = `<div class="alert alert-danger"><i class="bi bi-x-circle me-2"></i>${data.error}</div>`;
+                    }
+                })
+                .catch(e => {
+                    resultDiv.style.display = '';
+                    resultDiv.innerHTML = `<div class="alert alert-danger">Export failed: ${e}</div>`;
+                });
+        });
     });
 </script>
 

--- a/monksystem/base/urls.py
+++ b/monksystem/base/urls.py
@@ -34,5 +34,5 @@ urlpatterns = [
     path('download-MWF/<int:file_id>/', views.download_mwf, name='download_mwf'),
     path('plot_graph/<int:file_id>/', views.plot_graph, name='plot_graph'),
     path('download-CSV-Format/<int:file_id>/', views.download_format_csv, name='download_format_csv'),
-    
+    path('list-export-dirs/', views.list_export_dirs_view, name='list_export_dirs'),
 ]

--- a/monksystem/base/utils.py
+++ b/monksystem/base/utils.py
@@ -1,7 +1,9 @@
 import os
 import re
+import shutil
 import tempfile
 from datetime import datetime
+from pathlib import Path
 
 from django.db import IntegrityError
 from django.contrib import messages
@@ -82,12 +84,38 @@ def process_and_create_subject(file, request):
         )
 
 
+EXPORT_BASE_DIR = "/run/media/rafael"
+
+
+def list_export_dirs():
+    """Return a list of (name, path) tuples for each subdir of EXPORT_BASE_DIR."""
+    base = Path(EXPORT_BASE_DIR)
+    if not base.is_dir():
+        return []
+    return sorted(
+        (entry.name, str(entry))
+        for entry in base.iterdir()
+        if entry.is_dir()
+    )
+
+
+def _safe_export_path(target_dir: str, filename: str) -> Path:
+    """Return resolved destination path; raises ValueError if outside EXPORT_BASE_DIR."""
+    base = Path(EXPORT_BASE_DIR).resolve()
+    dest_dir = Path(target_dir).resolve()
+    dest_dir.relative_to(base)  # raises ValueError if outside base
+    dest = dest_dir / filename
+    dest.relative_to(base)      # guard against filename tricks
+    return dest
+
+
 @login_required
 @require_POST
 def download_format_csv(request, file_id):
     selected_channels = request.POST.getlist("channels")
     start_time_str = request.POST.get("start_time")
     end_time_str = request.POST.get("end_time")
+    export_dir = request.POST.get("export_dir", "").strip()
     start_seconds = float(start_time_str) if start_time_str else 0.0
     end_seconds = float(end_time_str) if end_time_str else 0.0
 
@@ -104,13 +132,36 @@ def download_format_csv(request, file_id):
     if start_time_str or end_time_str:
         data.setIntervalSelection(start_seconds, end_seconds)
 
+    csv_name = os.path.splitext(os.path.basename(file.file.path))[0] + ".csv"
+
+    if export_dir:
+        # Write directly to the chosen directory on external media
+        try:
+            dest_path = _safe_export_path(export_dir, csv_name)
+        except ValueError:
+            return JsonResponse({"error": "Invalid export directory."}, status=400)
+
+        fd, tmp_path = tempfile.mkstemp(suffix=".csv")
+        os.close(fd)
+        try:
+            data.writeToCsv(tmp_path)
+            shutil.move(tmp_path, str(dest_path))
+        except Exception as e:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            return JsonResponse({"error": f"Export failed: {e}"}, status=500)
+
+        return JsonResponse({"status": "ok", "path": str(dest_path)})
+
+    # Fallback: stream as browser download
     fd, tmp_path = tempfile.mkstemp(suffix=".csv")
     os.close(fd)
     try:
         data.writeToCsv(tmp_path)
         with open(tmp_path, "rb") as f:
             response = HttpResponse(f.read(), content_type="text/csv")
-        csv_name = os.path.splitext(os.path.basename(file.file.path))[0] + ".csv"
         response["Content-Disposition"] = f'attachment; filename="{csv_name}"'
         return response
     finally:

--- a/monksystem/base/views.py
+++ b/monksystem/base/views.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.files import File as DjangoFile
 from django.db.models import Q
 from django.shortcuts import render, redirect, get_object_or_404
-from django.http import HttpResponseForbidden
+from django.http import HttpResponseForbidden, JsonResponse
 from django.contrib import messages
 from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
@@ -22,6 +22,7 @@ from .utils import (
     download_mfer_header,
     download_mwf,
     plot_graph,
+    list_export_dirs,
 )
 
 
@@ -445,3 +446,11 @@ def import_from_directory(request):
         "available_files": available,
         "base_dir": base_dir,
     })
+
+
+@login_required
+@require_GET
+def list_export_dirs_view(request):
+    """Return JSON list of available export directories under /run/media/rafael."""
+    dirs = [{"name": name, "path": path} for name, path in list_export_dirs()]
+    return JsonResponse({"dirs": dirs})


### PR DESCRIPTION
- Add python-whitenoise to manifest
- Implement export directory listing from /run/media/rafael
- Add modal dialog for selecting USB drive as export destination
- Add AJAX-based CSV export with progress feedback
- Include path validation to prevent directory traversal
- Fall back to browser download if no export directory selected