### PR TITLE
ENH: Add USB drive import tab for .mwf files

### DIFF
--- a/monksystem/base/templates/base/import_file.html
+++ b/monksystem/base/templates/base/import_file.html
@@ -22,11 +22,18 @@
             </button>
         </li>
         <li class="nav-item" role="presentation">
-            <button class="nav-link{% if server_import %} active{% endif %}" id="dir-tab"
+            <button class="nav-link" id="dir-tab"
                     data-bs-toggle="tab" data-bs-target="#dir"
-                    type="button" role="tab" aria-controls="dir"
-                    aria-selected="{% if server_import %}true{% else %}false{% endif %}">
+                    type="button" role="tab" aria-controls="dir" aria-selected="false">
                 <i class="bi bi-folder2-open me-1"></i>From Server
+            </button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link{% if server_import %} active{% endif %}" id="usb-tab"
+                    data-bs-toggle="tab" data-bs-target="#usb"
+                    type="button" role="tab" aria-controls="usb"
+                    aria-selected="{% if server_import %}true{% else %}false{% endif %}">
+                <i class="bi bi-usb-drive me-1"></i>From USB
             </button>
         </li>
     </ul>
@@ -40,7 +47,7 @@
             <div class="alert alert-warning d-flex align-items-center" role="alert">
                 <i class="bi bi-exclamation-triangle-fill me-2"></i>
                 Browser file dialogs are not available in kiosk mode.
-                Use the <strong>&nbsp;From Server&nbsp;</strong> tab to import files.
+                Use the <strong>&nbsp;From USB&nbsp;</strong> tab to import files.
             </div>
             {% else %}
             <p class="text-muted small">Provide a title and select a single .mwf file to import.</p>
@@ -71,7 +78,7 @@
             <div class="alert alert-warning d-flex align-items-center" role="alert">
                 <i class="bi bi-exclamation-triangle-fill me-2"></i>
                 Browser file dialogs are not available in kiosk mode.
-                Use the <strong>&nbsp;From Server&nbsp;</strong> tab to import files.
+                Use the <strong>&nbsp;From USB&nbsp;</strong> tab to import files.
             </div>
             {% else %}
             <p class="text-muted small">Select multiple .mwf files to import at once. Titles are set from filenames.</p>
@@ -92,7 +99,7 @@
         </div>
 
         <!-- From server tab -->
-        <div class="tab-pane fade{% if server_import %} show active{% endif %}" id="dir"
+        <div class="tab-pane fade" id="dir"
              role="tabpanel" aria-labelledby="dir-tab">
             <p class="text-muted small">
                 Import .mwf files directly from the configured server directory
@@ -103,6 +110,145 @@
             </a>
         </div>
 
+        <!-- From USB tab -->
+        <div class="tab-pane fade{% if server_import %} show active{% endif %}" id="usb"
+             role="tabpanel" aria-labelledby="usb-tab">
+            <p class="text-muted small">Import .mwf files directly from a connected USB drive.</p>
+
+            <div id="usb-drives-section">
+                <p class="text-muted small mb-2">Select a USB drive:</p>
+                <div id="usb-drives-list" class="d-flex flex-wrap gap-2 mb-3">
+                    <span class="text-muted fst-italic" id="usb-drives-placeholder">Loading drives…</span>
+                </div>
+            </div>
+
+            <div id="usb-files-section" class="d-none">
+                <p class="text-muted small mb-2">
+                    Drive: <strong id="usb-selected-drive-name"></strong>
+                    <button type="button" class="btn btn-link btn-sm p-0 ms-2" id="usb-change-drive">Change</button>
+                </p>
+                <form method="post" action="{% url 'import_from_usb' %}" id="usb-import-form">
+                    {% csrf_token %}
+                    <input type="hidden" name="usb_dir" id="usb-dir-input">
+                    <div id="usb-file-list" class="list-group mb-3"></div>
+                    <div class="d-flex justify-content-between align-items-center">
+                        <button type="button" class="btn btn-sm btn-outline-secondary" id="usb-select-all">
+                            Select all
+                        </button>
+                        <button type="submit" class="btn btn-primary">
+                            <i class="bi bi-usb-drive me-1"></i>Import selected
+                        </button>
+                    </div>
+                </form>
+            </div>
+
+            <div id="usb-no-drives" class="d-none">
+                <div class="alert alert-info mb-0">No USB drives detected.</div>
+            </div>
+
+            <div id="usb-no-files" class="d-none">
+                <div class="alert alert-info mb-0">No .mwf files found on this drive.</div>
+                <div class="text-center mt-3">
+                    <button type="button" class="btn btn-outline-secondary btn-sm" id="usb-back-from-no-files">
+                        <i class="bi bi-arrow-left me-1"></i>Choose another drive
+                    </button>
+                </div>
+            </div>
+        </div>
+
     </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+(function () {
+    const tab = document.getElementById('usb-tab');
+    if (!tab) return;
+
+    var drivesRendered = false;
+
+    function showSection(id) {
+        ['usb-drives-section', 'usb-files-section', 'usb-no-drives', 'usb-no-files'].forEach(function (s) {
+            document.getElementById(s).classList.add('d-none');
+        });
+        document.getElementById(id).classList.remove('d-none');
+    }
+
+    function loadDrives() {
+        drivesRendered = false;
+        showSection('usb-drives-section');
+        document.getElementById('usb-drives-placeholder').classList.remove('d-none');
+        document.getElementById('usb-drives-placeholder').textContent = 'Loading drives…';
+        document.getElementById('usb-drives-list').innerHTML =
+            '<span class="text-muted fst-italic" id="usb-drives-placeholder">Loading drives…</span>';
+
+        fetch("{% url 'list_export_dirs' %}")
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                var list = document.getElementById('usb-drives-list');
+                list.innerHTML = '';
+                if (!data.dirs || data.dirs.length === 0) {
+                    showSection('usb-no-drives');
+                    return;
+                }
+                data.dirs.forEach(function (d) {
+                    var btn = document.createElement('button');
+                    btn.type = 'button';
+                    btn.className = 'btn btn-outline-secondary';
+                    btn.innerHTML = '<i class="bi bi-usb-drive me-1"></i>' + d.name;
+                    btn.addEventListener('click', function () { loadFiles(d.name, d.path); });
+                    list.appendChild(btn);
+                });
+                showSection('usb-drives-section');
+                drivesRendered = true;
+            })
+            .catch(function () { showSection('usb-no-drives'); });
+    }
+
+    function loadFiles(driveName, drivePath) {
+        document.getElementById('usb-selected-drive-name').textContent = driveName;
+        document.getElementById('usb-dir-input').value = drivePath;
+        var fileList = document.getElementById('usb-file-list');
+        fileList.innerHTML = '<span class="text-muted fst-italic">Loading files…</span>';
+        showSection('usb-files-section');
+
+        fetch("{% url 'list_usb_mwf_files' %}?dir=" + encodeURIComponent(drivePath))
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                fileList.innerHTML = '';
+                if (!data.files || data.files.length === 0) {
+                    showSection('usb-no-files');
+                    return;
+                }
+                data.files.forEach(function (name) {
+                    var label = document.createElement('label');
+                    label.className = 'list-group-item list-group-item-action';
+                    label.innerHTML = '<input type="checkbox" name="filenames" value="' +
+                        name.replace(/"/g, '&quot;') + '" class="me-2"> ' + name;
+                    fileList.appendChild(label);
+                });
+            })
+            .catch(function () {
+                fileList.innerHTML = '<span class="text-danger">Failed to load files.</span>';
+            });
+    }
+
+    document.getElementById('usb-change-drive').addEventListener('click', loadDrives);
+    document.getElementById('usb-back-from-no-files').addEventListener('click', loadDrives);
+
+    document.getElementById('usb-select-all').addEventListener('click', function () {
+        var cbs = document.querySelectorAll('#usb-file-list input[name="filenames"]');
+        var allChecked = Array.from(cbs).every(function (cb) { return cb.checked; });
+        cbs.forEach(function (cb) { cb.checked = !allChecked; });
+        this.textContent = allChecked ? 'Select all' : 'Deselect all';
+    });
+
+    tab.addEventListener('shown.bs.tab', function () {
+        if (!drivesRendered) { loadDrives(); }
+    });
+
+    if (tab.classList.contains('active')) { loadDrives(); }
+})();
+</script>
 {% endblock %}

--- a/monksystem/base/urls.py
+++ b/monksystem/base/urls.py
@@ -35,4 +35,6 @@ urlpatterns = [
     path('plot_graph/<int:file_id>/', views.plot_graph, name='plot_graph'),
     path('download-CSV-Format/<int:file_id>/', views.download_format_csv, name='download_format_csv'),
     path('list-export-dirs/', views.list_export_dirs_view, name='list_export_dirs'),
+    path('list-usb-mwf-files/', views.list_usb_mwf_files_view, name='list_usb_mwf_files'),
+    path('import-from-usb/', views.import_from_usb, name='import_from_usb'),
 ]

--- a/monksystem/base/utils.py
+++ b/monksystem/base/utils.py
@@ -99,6 +99,30 @@ def list_export_dirs():
     )
 
 
+def list_usb_mwf_files(usb_dir: str) -> list:
+    """Return sorted list of relative .mwf paths in usb_dir (recursive), validated under EXPORT_BASE_DIR."""
+    base = Path(EXPORT_BASE_DIR).resolve()
+    target = Path(usb_dir).resolve()
+    target.relative_to(base)  # raises ValueError if outside base
+    if not target.is_dir():
+        return []
+    return sorted(
+        str(f.relative_to(target))
+        for f in target.rglob("*")
+        if f.is_file() and f.suffix.lower() == ".mwf"
+    )
+
+
+def _safe_usb_import_path(usb_dir: str, name: str) -> Path:
+    """Return resolved path for name inside usb_dir, validated under EXPORT_BASE_DIR."""
+    base = Path(EXPORT_BASE_DIR).resolve()
+    target_dir = Path(usb_dir).resolve()
+    target_dir.relative_to(base)  # raises ValueError if outside base
+    candidate = (target_dir / name).resolve()
+    candidate.relative_to(base)   # guard against filename tricks
+    return candidate
+
+
 def _safe_export_path(target_dir: str, filename: str) -> Path:
     """Return resolved destination path; raises ValueError if outside EXPORT_BASE_DIR."""
     base = Path(EXPORT_BASE_DIR).resolve()

--- a/monksystem/base/views.py
+++ b/monksystem/base/views.py
@@ -23,6 +23,8 @@ from .utils import (
     download_mwf,
     plot_graph,
     list_export_dirs,
+    list_usb_mwf_files,
+    _safe_usb_import_path,
 )
 
 
@@ -454,3 +456,65 @@ def list_export_dirs_view(request):
     """Return JSON list of available export directories under /run/media/rafael."""
     dirs = [{"name": name, "path": path} for name, path in list_export_dirs()]
     return JsonResponse({"dirs": dirs})
+
+
+@login_required
+@require_GET
+def list_usb_mwf_files_view(request):
+    """Return JSON list of .mwf files in the given USB subdirectory."""
+    usb_dir = request.GET.get("dir", "").strip()
+    if not usb_dir:
+        return JsonResponse({"error": "No directory specified."}, status=400)
+    try:
+        files = list_usb_mwf_files(usb_dir)
+    except ValueError:
+        return JsonResponse({"error": "Invalid directory."}, status=400)
+    return JsonResponse({"files": files})
+
+
+@login_required
+def import_from_usb(request):
+    """Import selected .mwf files from a USB drive subdirectory."""
+    if request.method != "POST":
+        return redirect("import_file")
+
+    usb_dir = request.POST.get("usb_dir", "").strip()
+    filenames = request.POST.getlist("filenames")
+
+    if not usb_dir:
+        messages.error(request, "No USB drive selected.")
+        return redirect("import_file")
+    if not filenames:
+        messages.error(request, "No files selected.")
+        return redirect("import_file")
+
+    try:
+        user_profile = request.user.userprofile
+    except UserProfile.DoesNotExist:
+        messages.error(request, "You are not registered as a regular user.")
+        return redirect("view_files")
+
+    imported = 0
+    for name in filenames:
+        if not name.lower().endswith(".mwf"):
+            messages.error(request, f"Skipped non-.mwf file: {name}")
+            continue
+        try:
+            safe_path = _safe_usb_import_path(usb_dir, name)
+        except ValueError:
+            messages.error(request, f"Invalid filename rejected: {name}")
+            continue
+        if not safe_path.is_file():
+            messages.error(request, f"File no longer available: {name}")
+            continue
+        with open(safe_path, "rb") as fh:
+            django_file = DjangoFile(fh, name=safe_path.name)
+            title = safe_path.stem
+            new_file = File.objects.create(file=django_file, title=title)
+            FileImport.objects.create(user=user_profile, file=new_file)
+            process_and_create_subject(new_file, request)
+        imported += 1
+
+    if imported:
+        messages.success(request, f"{imported} file(s) imported successfully.")
+    return redirect("view_files")


### PR DESCRIPTION
- Add new "From USB" tab in import_file.html with drive selection UI
- Move "From Server" tab to middle position (no longer default active)
- Add backend endpoints for listing USB drives and their .mwf files
- Implement import_from_usb view to handle batch imports from USB
- Add helper functions list_usb_mwf_files and _safe_usb_import_path
- Include JavaScript for dynamic drive/file loading and selection
- Update kiosk mode warnings to reference USB tab instead of server