### PR TITLE
workflow: simplify home page — 3-step workflow, action cards, recent files

### DIFF
--- a/monksystem/base/static/base/css/custom.css
+++ b/monksystem/base/static/base/css/custom.css
@@ -366,3 +366,170 @@ h1, h2, h3, h4, h5, h6,
   }
 
 }
+
+/* 8. Home page
+   ────────────────────────────────────────────────────────────────────────── */
+
+/* Hero */
+.monk-hero {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: var(--monk-surface);
+  border: 1px solid var(--monk-border);
+  border-left: 4px solid var(--monk-primary);
+  border-radius: var(--monk-radius-lg);
+  padding: 1.75rem 2rem;
+  box-shadow: var(--monk-shadow);
+}
+.monk-hero__brand {
+  font-family: 'Figtree', system-ui, sans-serif;
+  font-weight: 700;
+  font-size: 1.75rem;
+  color: var(--monk-primary);
+  margin-bottom: 0.4rem;
+}
+.monk-hero__sub {
+  color: var(--monk-muted);
+  font-size: 0.95rem;
+  margin: 0;
+  max-width: 520px;
+}
+
+/* Workflow steps */
+.monk-workflow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.monk-workflow__step {
+  flex: 1;
+  background: var(--monk-surface);
+  border: 1px solid var(--monk-border);
+  border-radius: var(--monk-radius-lg);
+  padding: 1.25rem 1rem;
+  text-align: center;
+  position: relative;
+}
+.monk-workflow__num {
+  position: absolute;
+  top: -0.6rem;
+  left: 1rem;
+  background: var(--monk-primary);
+  color: #fff;
+  font-family: 'Figtree', system-ui, sans-serif;
+  font-weight: 700;
+  font-size: 0.75rem;
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.monk-workflow__icon {
+  font-size: 1.75rem;
+  color: var(--monk-primary);
+  margin-bottom: 0.5rem;
+}
+.monk-workflow__label {
+  font-family: 'Figtree', system-ui, sans-serif;
+  font-weight: 600;
+  font-size: 0.95rem;
+  margin-bottom: 0.3rem;
+}
+.monk-workflow__desc {
+  font-size: 0.8rem;
+  color: var(--monk-muted);
+  line-height: 1.4;
+}
+.monk-workflow__arrow {
+  color: var(--monk-border);
+  font-size: 1.25rem;
+  flex-shrink: 0;
+}
+
+/* Action cards */
+.monk-action-card {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: var(--monk-surface);
+  border: 1px solid var(--monk-border);
+  border-radius: var(--monk-radius-lg);
+  padding: 1.25rem;
+  text-decoration: none;
+  color: var(--monk-text);
+  box-shadow: var(--monk-shadow);
+  transition: box-shadow .2s ease, border-color .2s ease, transform .15s ease;
+  height: 100%;
+}
+.monk-action-card:hover {
+  box-shadow: var(--monk-shadow-md);
+  border-color: #BFDBFE;
+  transform: translateY(-2px);
+  color: var(--monk-text);
+  text-decoration: none;
+}
+.monk-action-card__icon {
+  width: 3rem;
+  height: 3rem;
+  border-radius: var(--monk-radius);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  flex-shrink: 0;
+}
+.monk-action-card__body { flex: 1; }
+.monk-action-card__title {
+  font-family: 'Figtree', system-ui, sans-serif;
+  font-weight: 600;
+  font-size: 1rem;
+  margin-bottom: 0.2rem;
+}
+.monk-action-card__desc {
+  font-size: 0.85rem;
+  color: var(--monk-muted);
+}
+.monk-action-card__arrow {
+  color: var(--monk-border);
+  transition: transform .15s ease, color .15s ease;
+}
+.monk-action-card:hover .monk-action-card__arrow {
+  transform: translateX(4px);
+  color: var(--monk-primary);
+}
+
+/* Recent files */
+.monk-recent__heading {
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  color: var(--monk-muted);
+  margin-bottom: 0.75rem;
+}
+.monk-recent__list {
+  border-radius: var(--monk-radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--monk-border);
+}
+.monk-recent__item {
+  display: flex;
+  align-items: center;
+  padding: 0.7rem 1rem;
+  font-size: 0.9rem;
+  border-left: none;
+  border-right: none;
+  transition: background .15s ease;
+}
+.monk-recent__item:first-child { border-top: none; }
+.monk-recent__item:last-child  { border-bottom: none; }
+.monk-recent__item:hover { background: #EFF6FF; color: var(--monk-primary); }
+.monk-recent__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/monksystem/base/templates/base/home.html
+++ b/monksystem/base/templates/base/home.html
@@ -1,66 +1,102 @@
 {% extends 'main.html' %}
 
-{% load static %}
-
 {% block title %}Home — MONK{% endblock %}
 
 {% block content %}
-<div class="container mt-5">
+<div class="container py-5">
 
-    <div class="p-4 mb-4 bg-dark text-white rounded">
-        <h1 class="mb-2">MONK</h1>
-        <p class="mb-0 text-white-50">
-            Medical waveform management for Nihon-Kohden MFER data.
-            Import, organize, visualize, and export ECG and vital-sign recordings.
-        </p>
+    <!-- Hero -->
+    <div class="monk-hero mb-5">
+        <div class="monk-hero__body">
+            <div class="monk-hero__brand">
+                <i class="bi bi-activity"></i> MONK
+            </div>
+            <p class="monk-hero__sub">
+                Nihon-Kohden MFER waveform management —
+                import, visualize, and export ECG and vital-sign recordings.
+            </p>
+        </div>
+        {% if total_files > 0 %}
+        <div class="monk-stat-pill">
+            <i class="bi bi-file-earmark-medical text-primary"></i>
+            <span><strong>{{ total_files }}</strong> file{{ total_files|pluralize }} imported</span>
+        </div>
+        {% endif %}
     </div>
 
-    <div class="row text-center g-4">
-
-        <div class="col-md-6">
-            <div class="card h-100">
-                <div class="card-body">
-                    <i class="bi bi-cloud-upload fs-2 text-primary mb-2"></i>
-                    <h3 class="card-title">Import Files</h3>
-                    <p class="card-text">Upload .mwf waveform files from your computer or a server directory.</p>
-                    <a href="{% url 'import_file' %}" class="btn btn-primary">Import</a>
-                </div>
-            </div>
+    <!-- Workflow steps -->
+    <div class="monk-workflow mb-5">
+        <div class="monk-workflow__step">
+            <div class="monk-workflow__num">1</div>
+            <div class="monk-workflow__icon"><i class="bi bi-usb-drive"></i></div>
+            <div class="monk-workflow__label">Import</div>
+            <div class="monk-workflow__desc">Plug in a USB drive and import <code>.mwf</code> files</div>
         </div>
-
-        <div class="col-md-6">
-            <div class="card h-100">
-                <div class="card-body">
-                    <i class="bi bi-file-earmark-medical fs-2 text-primary mb-2"></i>
-                    <h3 class="card-title">View Files</h3>
-                    <p class="card-text">Browse, visualize, and export your imported waveform recordings.</p>
-                    <a href="{% url 'view_files' %}" class="btn btn-primary">Browse</a>
-                </div>
-            </div>
+        <div class="monk-workflow__arrow"><i class="bi bi-chevron-right"></i></div>
+        <div class="monk-workflow__step">
+            <div class="monk-workflow__num">2</div>
+            <div class="monk-workflow__icon"><i class="bi bi-graph-up"></i></div>
+            <div class="monk-workflow__label">Visualize</div>
+            <div class="monk-workflow__desc">Plot waveform channels interactively</div>
         </div>
-
-        <div class="col-md-6">
-            <div class="card h-100">
-                <div class="card-body">
-                    <i class="bi bi-briefcase fs-2 text-primary mb-2"></i>
-                    <h3 class="card-title">View Projects</h3>
-                    <p class="card-text">Manage research projects and control access to subjects and recordings.</p>
-                    <a href="{% url 'view_projects' %}" class="btn btn-primary">Projects</a>
-                </div>
-            </div>
+        <div class="monk-workflow__arrow"><i class="bi bi-chevron-right"></i></div>
+        <div class="monk-workflow__step">
+            <div class="monk-workflow__num">3</div>
+            <div class="monk-workflow__icon"><i class="bi bi-filetype-csv"></i></div>
+            <div class="monk-workflow__label">Export</div>
+            <div class="monk-workflow__desc">Save selected channels as CSV to external media</div>
         </div>
-
-        <div class="col-md-6">
-            <div class="card h-100">
-                <div class="card-body">
-                    <i class="bi bi-journal-bookmark fs-2 text-primary mb-2"></i>
-                    <h3 class="card-title">View Subjects</h3>
-                    <p class="card-text">Explore subject records extracted from imported waveform file headers.</p>
-                    <a href="{% url 'view_subjects' %}" class="btn btn-primary">Subjects</a>
-                </div>
-            </div>
-        </div>
-
     </div>
+
+    <!-- Primary actions -->
+    <div class="row g-3 mb-5">
+        <div class="col-md-6">
+            <a href="{% url 'import_file' %}" class="monk-action-card">
+                <div class="monk-action-card__icon bg-primary-subtle">
+                    <i class="bi bi-upload text-primary"></i>
+                </div>
+                <div class="monk-action-card__body">
+                    <div class="monk-action-card__title">Import Files</div>
+                    <div class="monk-action-card__desc">Load <code>.mwf</code> recordings from USB or server</div>
+                </div>
+                <i class="bi bi-chevron-right monk-action-card__arrow"></i>
+            </a>
+        </div>
+        <div class="col-md-6">
+            <a href="{% url 'view_files' %}" class="monk-action-card">
+                <div class="monk-action-card__icon bg-success-subtle">
+                    <i class="bi bi-files text-success"></i>
+                </div>
+                <div class="monk-action-card__body">
+                    <div class="monk-action-card__title">Browse Files</div>
+                    <div class="monk-action-card__desc">Open, visualize, and export imported recordings</div>
+                </div>
+                <i class="bi bi-chevron-right monk-action-card__arrow"></i>
+            </a>
+        </div>
+    </div>
+
+    <!-- Recent files -->
+    {% if recent_files %}
+    <div class="monk-recent">
+        <h5 class="monk-recent__heading">
+            <i class="bi bi-clock-history me-2 text-muted"></i>Recent
+        </h5>
+        <div class="list-group monk-recent__list">
+            {% for file in recent_files %}
+            <a href="{% url 'file' file.id %}" class="list-group-item list-group-item-action monk-recent__item">
+                <i class="bi bi-file-earmark-waveform me-2 text-primary"></i>
+                <span class="monk-recent__name">{{ file.title }}</span>
+                {% with file.fileimport_set.first as imp %}
+                {% if imp %}
+                <small class="text-muted ms-auto">{{ imp.imported_at|date:"Y-m-d H:i" }}</small>
+                {% endif %}
+                {% endwith %}
+            </a>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
 </div>
 {% endblock %}

--- a/monksystem/base/views.py
+++ b/monksystem/base/views.py
@@ -32,7 +32,21 @@ from .utils import (
 @login_required
 @require_GET
 def home_page(request):
-    return render(request, "base/home.html")
+    try:
+        user_profile = request.user.userprofile
+        total_files = File.objects.filter(fileimport__user=user_profile).distinct().count()
+        recent_files = (
+            File.objects.filter(fileimport__user=user_profile)
+            .distinct()
+            .order_by("-fileimport__imported_at")[:5]
+        )
+    except UserProfile.DoesNotExist:
+        total_files = 0
+        recent_files = File.objects.none()
+    return render(request, "base/home.html", {
+        "total_files": total_files,
+        "recent_files": recent_files,
+    })
 
 
 @login_required


### PR DESCRIPTION
## Summary

- Removes Projects and Subjects cards from the home page
- New hero strip with left blue accent and file count pill
- 3-step workflow diagram (Import → Visualize → Export) with numbered badges
- Two primary action cards (Import Files, Browse Files) with hover-lift
- Recent files list showing the last 5 imported files with timestamps

## Test plan

- [ ] Home page loads correctly when logged in
- [ ] File count pill appears when files have been imported
- [ ] Recent files list shows up to 5 entries with correct titles and timestamps
- [ ] Both action cards navigate to the correct pages
- [ ] Home page shows cleanly with no Projects or Subjects references